### PR TITLE
Fixed 'New Game' button functionality

### DIFF
--- a/Memory-block-game-main/code/styles.js
+++ b/Memory-block-game-main/code/styles.js
@@ -127,5 +127,6 @@ function resetGame() {
 const playAgainButton = document.getElementById("play-again");
 playAgainButton.addEventListener("click", resetGame);
 
+document.getElementById("reset").addEventListener("click",resetGame);
 
 });


### PR DESCRIPTION
Linked the 'New Game' button to the resetGame() function, ensuring it triggers the game reset when clicked.
This ensures the game resets properly and starts a new round for the player.


https://github.com/user-attachments/assets/e02261ec-1854-487c-8bfc-9c4bd916d0aa

