### PR TITLE
Fix preserve player identity

### DIFF
--- a/Memory-block-game-main/code/script.js
+++ b/Memory-block-game-main/code/script.js
@@ -32,6 +32,7 @@ document.addEventListener("DOMContentLoaded", () => {
     // Tie-breaker variables
     let tieMode = false;
     let tiePlayers = [];
+    let originalTiePlayers = [];
 
     function initializeBoard() {
         const shuffledImages = shuffle([...images]);
@@ -188,6 +189,7 @@ document.addEventListener("DOMContentLoaded", () => {
     }
 
     function startTieBreaker() {
+        originalTiePlayers = [...tiePlayers];
     alert(
         `Tie detected between Player ${tiePlayers.join(
             " & "
@@ -214,7 +216,7 @@ document.addEventListener("DOMContentLoaded", () => {
         const popup = document.getElementById("congratulation-popup");
 
         popup.querySelector("p").textContent =
-            `Player ${currentPlayer} Wins the Tie-Breaker! 🏆`;
+            `Player ${originalTiePlayers[currentPlayer - 1]} Wins the Tie-Breaker! 🏆`
 
         popup.style.display = "block";
 


### PR DESCRIPTION
This PR fixes the issue where original player identity was lost during tie-breaker rounds.
Problem
When a tie occurred, players were renumbered starting from Player 1 during sudden death.
This caused the final winner message to display incorrect original player numbers.

Solution
- Stored original tied player numbers before starting tie-breaker.
- Used stored original player numbers when announcing tie-breaker winner.
- No changes were made to normal game flow.

Fixes #56