### PR TITLE
Improve keyboard accessibility for memory cards and controls

### DIFF
--- a/Memory-block-game-main/code/script.js
+++ b/Memory-block-game-main/code/script.js
@@ -142,7 +142,18 @@ document.addEventListener("DOMContentLoaded", () => {
             face.style.display = "none";
             block.appendChild(face);
 
-            block.addEventListener("click", flipBlock);
+            block.setAttribute("tabindex", "0");
+block.setAttribute("role", "button");
+block.setAttribute("aria-label", "Memory card");
+
+block.addEventListener("click", flipBlock);
+
+block.addEventListener("keydown", (e) => {
+    if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        flipBlock.call(block);
+    }
+});
         });
 
         resetBoard();

--- a/Memory-block-game-main/code/styles.css
+++ b/Memory-block-game-main/code/styles.css
@@ -399,3 +399,16 @@ select:disabled {
     box-shadow: 0 0 30px #FFD700;
     border: 2px solid white;
 }
+}
+/* ── Keyboard Accessibility ───────────────────── */
+
+.block:focus-visible {
+    outline: 4px solid #fbbf24;
+    outline-offset: 4px;
+}
+
+button:focus-visible,
+select:focus-visible {
+    outline: 3px solid #fbbf24;
+    outline-offset: 3px;
+}


### PR DESCRIPTION
## 📌 Description
This pull request improves the accessibility of the Memory Block Game by adding full keyboard support.
Previously, the game could only be played using mouse or touch input, which limited accessibility for keyboard-only and assistive technology users.

---

## 🔗 Related Issue
Closes: #71 

---

## 🛠 Changes Made
- Made all game cards focusable using the Tab key
- Enabled cards to flip using Enter or Space

---



## ✅ Checklist
- [x] I have tested my changes
- [x] My code follows project guidelines
- [x] I have linked the related issue
