### PR TITLE
Missing Tie-Breaker Logic solved

### DIFF
--- a/Memory-block-game-main/code/script.js
+++ b/Memory-block-game-main/code/script.js
@@ -368,7 +368,7 @@ playSound(flipSound);
 
         if (matchedPairs === totalPairs) {
             playSound(winSound);
-            document.getElementById("congratulation-popup").style.display = "block";
+            showCongratulations();
             gameOver = true;
         }
 
@@ -428,22 +428,18 @@ playSound(flipSound);
             }
         }
 
-        // Single winner
+        const popup = document.getElementById("congratulation-popup");
         if (winners.length === 1) {
-            const popup = document.getElementById("congratulation-popup");
             if (totalPlayers === 1) {
                 popup.querySelector("p").textContent = "You completed the game! 🏆";
             } else {
                 popup.querySelector("p").textContent = `Player ${winners[0]} Wins! 🏆`;
             }
-            popup.style.display = "block";
-            return;
+        } else {
+            // Handle the tie gracefully
+            popup.querySelector("p").textContent = `It's a Tie between Players ${winners.join(" & ")}! 🤝`;
         }
-
-        // Tie detected
-        tieMode = true;
-        tiePlayers = winners;
-        startTieBreaker();
+        popup.style.display = "block";
     }
 
     function resetGame() {


### PR DESCRIPTION
## 📌 Description

When a multiplayer game ends in a tie, the game will now correctly display a message like "It's a Tie between Players 1 & 2
instead of crashing. Single-player and single-winner games continue to display their respective victory messages correctly.
---

## 🔗 Related Issue
Closes: #92 

---

## 🛠 Changes Made
In showCongratulations():
       Removed the logic that attempted to use undeclared variables (tieMode, tiePlayers) and the non-existent startTieBreaker()        
         function.
       Updated the logic to use an if/else block that gracefully handles ties by joining the winner names with " & " and displaying a   
         friendly message in the UI popup.
   In disableBlocks():
       Replaced the manual popup display with a call to showCongratulations(), ensuring the correct winner or tie message is calculated 
         and shown when the game ends.
## 📷 Screenshots (if applicable)

---

## ✅ Checklist
- [yes ] I have tested my changes
- [yes ] My code follows project guidelines
- [ yes] I have linked the related issue
