### PR TITLE
Duplicate Function Declaration solved

### DIFF
--- a/Memory-block-game-main/code/script.js
+++ b/Memory-block-game-main/code/script.js
@@ -171,12 +171,6 @@ document.addEventListener("click", () => {
     function unlockThemeControl() { document.getElementById("theme-select").disabled = false; }
 
     // ── Grid size helpers ────────────────────────────────────────────────────
-    function getGridDimensions() {
-        const rows = parseInt(document.getElementById("rows-select").value);
-        const cols = parseInt(document.getElementById("cols-select").value);
-        return { rows, cols };
-    }
-  
     const rowsSelect = document.getElementById("rows-select");
     const colsSelect = document.getElementById("cols-select");
 


### PR DESCRIPTION
## 📌 Description
Brief description of what this PR does.
The codebase now contains a single, clean source of truth for fetching grid dimensions, which improves maintainability and ensures
  consistent behavior throughout the application.

## 🔗 Related Issue
Closes: #93 

---

## 🛠 Changes Made
Removed  the first instance of getGridDimensions() located before the rowsSelect and colsSelect declarations.
  Kept the second instance located after applyDifficulty(), which correctly uses the cached rowsSelect and colsSelect elements.

## 📷 Screenshots (if applicable)

---

## ✅ Checklist
- [yes ] I have tested my changes
- [yes ] My code follows project guidelines
- [ yes] I have linked the related issue
